### PR TITLE
Remove object lifetime cast

### DIFF
--- a/phylactery/src/shroud.rs
+++ b/phylactery/src/shroud.rs
@@ -46,7 +46,13 @@ mod implement {
                 impl<$($generic: ?Sized,)* $($name,)* TConcrete: $trait<$($generic,)* $($name,)*> $(+ $traits)*> $crate::shroud::Shroud<TConcrete> for dyn $trait<$($generic,)* $($name,)* $($associate = TConcrete::$associate,)*> $(+ $traits)* where $($name: $bound,)* {
                     #[inline(always)]
                     fn shroud(from: ::core::ptr::NonNull<TConcrete>) -> ::core::ptr::NonNull<Self> {
-                        unsafe { ::core::ptr::NonNull::new_unchecked(from.as_ptr() as *mut _) }
+                        unsafe {
+                            let ptr = ::std::mem::transmute::<
+                                *mut (dyn $trait<$($generic,)* $($name,)* $($associate = TConcrete::$associate,)*> $(+ $traits)*  + '_),
+                                *mut (dyn $trait<$($generic,)* $($name,)* $($associate = TConcrete::$associate,)*> $(+ $traits)*  + 'static),
+                            >(from.as_ptr() as *mut _);
+                            ::core::ptr::NonNull::new_unchecked(ptr)
+                        }
                     }
                 }
             };
@@ -91,7 +97,13 @@ mod implement {
             impl<$($parameter,)* $return, TConcrete: $function($($parameter),*) -> $return $(+ $trait)*> $crate::shroud::Shroud<TConcrete> for dyn $function($($parameter),*) -> $return $(+ $trait)* {
                 #[inline(always)]
                 fn shroud(from: ::core::ptr::NonNull<TConcrete>) -> ::core::ptr::NonNull<Self> {
-                    unsafe { ::core::ptr::NonNull::new_unchecked(from.as_ptr() as *mut _) }
+                    unsafe {
+                        let ptr = ::std::mem::transmute::<
+                            *mut (dyn $function($($parameter),*) -> $return $(+ $trait)*  + '_),
+                            *mut (dyn $function($($parameter),*) -> $return $(+ $trait)*  + 'static),
+                        >(from.as_ptr() as *mut _);
+                        ::core::ptr::NonNull::new_unchecked(ptr)
+                    }
                 }
             }
         };


### PR DESCRIPTION
Hi there o/

I'm a member of the Rust Language's Types Team; as part of stabilizing the `arbitrary_self_types` and `derive_coerce_pointee` features we are changing what raw pointer casts are legal (rust-lang/rust#136702). Specifically, casting `*const dyn Trait + 'a` to `*const dyn Trait + 'b` where it is not able to be proven that `'a` outlives `'b` will become an error.

Without going into too much detail, the justification for this change is that casting trait object's lifetime bound to a lifetime that lives for a longer time could invalidate the VTable of the trait object, allowing for dispatching to methods that should not be callable. See this example from the linked issue:
```rust
#![forbid(unsafe_code)]
#![feature(arbitrary_self_types, derive_coerce_pointee)]

use std::any::TypeId;
use std::marker::{CoercePointee, PhantomData};

#[derive(CoercePointee)]
#[repr(transparent)]
struct SelfPtr<T: ?Sized>(*const T);

impl<T: ?Sized> std::ops::Deref for SelfPtr<T> {
    type Target = T;
    fn deref(&self) -> &T {
        panic!("please don't call me, I just want the `Receiver` impl!");
    }
}

trait GetTypeId {
    fn get_type_id(self: SelfPtr<Self>) -> TypeId
    where
        Self: 'static;
}

impl<T: ?Sized> GetTypeId for PhantomData<T> {
    fn get_type_id(self: SelfPtr<Self>) -> TypeId
    where
        Self: 'static,
    {
        TypeId::of::<T>()
    }
}

// no `T: 'static` bound necessary
fn type_id_of<T: ?Sized>() -> TypeId {
    let ptr = SelfPtr(
        &PhantomData::<T> as *const (dyn GetTypeId + '_) as *const (dyn GetTypeId + 'static),
    );
    ptr.get_type_id()
}

``` 

Unfortunately, going through the usual "future compatibility warning" process turned out to not be possible as checking lifetime constraints without emitting an error is prohibitively difficult to do in the implementation of the borrow checker. This means that you will never receive an FCW and its associated grace period to update your code to be compatible with the new rules.

I have attempted to update your codebase to the new rules for you so that it will still compile when we make this change. I hope this breakage won't cause you too much trouble and that you might even find the post-migration code to be better than how it was previously :-)

If you have any questions about why this change is required please let me know and I'll do my best to further explain the justification.